### PR TITLE
Initialize Symphony React Native skeleton

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import AppNavigator from './src/AppNavigator';
+import store from './src/store';
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <AppNavigator />
+    </Provider>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# symphony
+# Symphony
+
+A productivity and wellness app integrating task management, mood tracking, and sleep insights.
+
+## Features
+- Manage tasks with priorities and completion state.
+- Log daily moods in the journal.
+- View a dashboard with your next task and latest mood.
+- Placeholder screens for sleep insights and settings.
+
+This project uses React Native with Expo, React Navigation and Redux Toolkit. To run the project locally you will need Expo CLI and all dependencies listed in `package.json`.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "symphony",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^6.1.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "@reduxjs/toolkit": "^1.9.7",
+    "react-redux": "^8.1.1"
+  }
+}

--- a/src/AppNavigator.js
+++ b/src/AppNavigator.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './screens/HomeScreen';
+import TaskListScreen from './screens/TaskListScreen';
+import MoodJournalScreen from './screens/MoodJournalScreen';
+import SleepInsightsScreen from './screens/SleepInsightsScreen';
+import SettingsScreen from './screens/SettingsScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function AppNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Tasks" component={TaskListScreen} />
+        <Stack.Screen name="Mood" component={MoodJournalScreen} />
+        <Stack.Screen name="Sleep" component={SleepInsightsScreen} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
+
+export default function HomeScreen() {
+  const tasks = useSelector(state => state.tasks);
+  const mood = useSelector(state => state.mood);
+
+  const nextTask = tasks.find(t => !t.completed);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Symphony</Text>
+      <Text>Next Task: {nextTask ? nextTask.title : 'All done!'}</Text>
+      <Text>Last Mood: {mood.length ? mood[mood.length - 1].value : 'N/A'}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/MoodJournalScreen.js
+++ b/src/screens/MoodJournalScreen.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useDispatch } from 'react-redux';
+import { addMoodEntry } from '../store/moodSlice';
+
+export default function MoodJournalScreen() {
+  const [value, setValue] = useState('');
+  const dispatch = useDispatch();
+
+  const submit = () => {
+    dispatch(addMoodEntry({ id: Date.now().toString(), value }));
+    setValue('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Mood Journal</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="How do you feel?"
+        value={value}
+        onChangeText={setValue}
+      />
+      <Button title="Save" onPress={submit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  header: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Settings</Text>
+      <Text>Preference options will be here.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/SleepInsightsScreen.js
+++ b/src/screens/SleepInsightsScreen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SleepInsightsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Sleep Insights</Text>
+      <Text>Integration with Health data coming soon.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+});

--- a/src/screens/TaskListScreen.js
+++ b/src/screens/TaskListScreen.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { View, FlatList, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useSelector, useDispatch } from 'react-redux';
+import { toggleTask } from '../store/tasksSlice';
+
+export default function TaskListScreen() {
+  const tasks = useSelector(state => state.tasks);
+  const dispatch = useDispatch();
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={tasks}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => dispatch(toggleTask(item.id))}>
+            <Text style={item.completed ? styles.done : styles.item}>{item.title}</Text>
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  item: {
+    fontSize: 18,
+    paddingVertical: 8,
+  },
+  done: {
+    fontSize: 18,
+    paddingVertical: 8,
+    textDecorationLine: 'line-through',
+    color: 'grey',
+  },
+});

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import tasksReducer from './tasksSlice';
+import moodReducer from './moodSlice';
+
+export const store = configureStore({
+  reducer: {
+    tasks: tasksReducer,
+    mood: moodReducer,
+  },
+});
+
+export default store;

--- a/src/store/moodSlice.js
+++ b/src/store/moodSlice.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const moodSlice = createSlice({
+  name: 'mood',
+  initialState: [],
+  reducers: {
+    addMoodEntry: (state, action) => {
+      state.push(action.payload);
+    },
+  },
+});
+
+export const { addMoodEntry } = moodSlice.actions;
+export default moodSlice.reducer;

--- a/src/store/tasksSlice.js
+++ b/src/store/tasksSlice.js
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const tasksSlice = createSlice({
+  name: 'tasks',
+  initialState: [],
+  reducers: {
+    addTask: (state, action) => {
+      state.push(action.payload);
+    },
+    removeTask: (state, action) => {
+      return state.filter(task => task.id !== action.payload);
+    },
+    toggleTask: (state, action) => {
+      const task = state.find(t => t.id === action.payload);
+      if (task) {
+        task.completed = !task.completed;
+      }
+    },
+  },
+});
+
+export const { addTask, removeTask, toggleTask } = tasksSlice.actions;
+export default tasksSlice.reducer;


### PR DESCRIPTION
## Summary
- initialize React Native project setup with Expo
- add Redux store with task and mood slices
- implement screens for home, tasks, mood journal, sleep insights and settings
- create navigator with basic routes
- update README with project overview

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe652cc7c8320a8304a500efddacf