### PR TITLE
Fix Expo Go SDK mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,18 @@ A productivity and wellness app integrating task management, mood tracking, and 
 - View a dashboard with your next task and latest mood.
 - Placeholder screens for sleep insights and settings.
 
-This project uses React Native with Expo, React Navigation and Redux Toolkit. To run the project locally you will need Expo CLI and all dependencies listed in `package.json`.
+This project uses React Native with Expo, React Navigation and Redux Toolkit. It now targets **Expo SDK&nbsp;53**, so be sure the Expo Go application on your device also uses SDK&nbsp;53. If you previously had an older version of Expo Go installed you may need to update it from the app store.
+
+To run the project locally you will need Expo CLI and all dependencies listed in `package.json`. After cloning the repo run:
+
+```bash
+npm install
+```
+
+Then start the development server with:
+
+```bash
+npm start
+```
+
+The project expects an `assets` directory at the root. A placeholder `.keep` file is committed so the folder exists even if you do not have custom images yet.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "symphony",
+    "slug": "symphony",
+    "version": "1.0.0",
+    "sdkVersion": "53.0.0",
+    "assetBundlePatterns": ["**/*"],
+    "orientation": "portrait",
+    "platforms": ["ios", "android", "web"]
+  }
+}

--- a/assets/.keep
+++ b/assets/.keep
@@ -1,0 +1,1 @@
+placeholder

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "expo": "^49.0.0",
+    "expo": "~53.0.0",
     "react": "18.2.0",
-    "react-native": "0.72.4",
+    "react-native": "0.74.0",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.12",
     "@react-navigation/bottom-tabs": "^6.5.16",


### PR DESCRIPTION
## Summary
- add Expo config for SDK 53
- bump Expo/React Native deps
- document new setup steps and assets folder
- include placeholder assets directory

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683feedfcca48320851229bc2a51ed9d