### PR TITLE
Add error boundary

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,11 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import AppNavigator from './src/AppNavigator';
 import store from './src/store';
+import ErrorBoundary from './src/ErrorBoundary';
 
 export default function App() {
   return (
     <Provider store={store}>
-      <AppNavigator />
+      <ErrorBoundary>
+        <AppNavigator />
+      </ErrorBoundary>
     </Provider>
   );
 }

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('Uncaught error:', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.title}>Something went wrong.</Text>
+          <Text style={styles.message}>{this.state.error.toString()}</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    marginBottom: 8,
+  },
+  message: {
+    fontSize: 16,
+    color: 'red',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add `ErrorBoundary` class component to display runtime errors
- wrap the app in the error boundary

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683ff6d4ffd48320b96ab8e6ad58d05e