### PR TITLE
Add Pomodoro timer and enhanced tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A productivity and wellness app integrating task management, mood tracking, and 
 
 ## Features
 - Manage tasks with priorities and completion state.
+- Add tasks with a due time and urgency level.
+- Start tasks with a built‑in Pomodoro timer that logs the time spent.
 - Log daily moods in the journal.
 - View a dashboard with your next task and latest mood.
 - Placeholder screens for sleep insights and settings.

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -15,7 +15,9 @@ export default function HomeScreen() {
       <View style={styles.card}>
         <Text style={styles.cardLabel}>Next Task</Text>
         <Text style={styles.cardValue}>
-          {nextTask ? nextTask.title : 'All done!'}
+          {nextTask
+            ? `${nextTask.title} (due ${nextTask.due || 'N/A'})`
+            : 'All done!'}
         </Text>
       </View>
       <View style={styles.card}>

--- a/src/screens/TaskListScreen.js
+++ b/src/screens/TaskListScreen.js
@@ -1,24 +1,121 @@
-import React from 'react';
-import { View, FlatList, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  FlatList,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  TextInput,
+  Button,
+} from 'react-native';
 import { colors } from '../theme';
 import { useSelector, useDispatch } from 'react-redux';
-import { toggleTask } from '../store/tasksSlice';
+import { addTask, toggleTask, startTask, stopTask } from '../store/tasksSlice';
 
 export default function TaskListScreen() {
   const tasks = useSelector(state => state.tasks);
   const dispatch = useDispatch();
 
+  const [title, setTitle] = useState('');
+  const [due, setDue] = useState('');
+  const [urgency, setUrgency] = useState('');
+
+  const submit = () => {
+    if (!title) return;
+    dispatch(
+      addTask({
+        id: Date.now().toString(),
+        title,
+        due,
+        urgency,
+        completed: false,
+        startedAt: null,
+        timeSpent: 0,
+      })
+    );
+    setTitle('');
+    setDue('');
+    setUrgency('');
+  };
+
+  const TaskItem = ({ item }) => {
+    const isRunning = !!item.startedAt;
+    const [remaining, setRemaining] = useState(1500);
+
+    useEffect(() => {
+      let interval;
+      if (isRunning) {
+        const update = () => {
+          const elapsed = Math.floor((Date.now() - item.startedAt) / 1000);
+          const r = 1500 - elapsed;
+          setRemaining(r > 0 ? r : 0);
+        };
+        update();
+        interval = setInterval(update, 1000);
+      }
+      return () => clearInterval(interval);
+    }, [isRunning, item.startedAt]);
+
+    const format = secs => {
+      const m = Math.floor(secs / 60)
+        .toString()
+        .padStart(2, '0');
+      const s = Math.floor(secs % 60)
+        .toString()
+        .padStart(2, '0');
+      return `${m}:${s}`;
+    };
+
+    return (
+      <View style={styles.taskRow}>
+        <TouchableOpacity
+          style={styles.taskInfo}
+          onPress={() => dispatch(toggleTask(item.id))}
+        >
+          <Text style={item.completed ? styles.done : styles.item}>{item.title}</Text>
+          <Text style={styles.meta}>{item.due} | urgency: {item.urgency}</Text>
+          {isRunning && (
+            <Text style={styles.timer}>Pomodoro {format(remaining)}</Text>
+          )}
+        </TouchableOpacity>
+        <Button
+          title={isRunning ? 'Stop' : 'Start'}
+          onPress={() =>
+            isRunning
+              ? dispatch(stopTask(item.id))
+              : dispatch(startTask(item.id))
+          }
+        />
+      </View>
+    );
+  };
+
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Tasks</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Task title"
+        value={title}
+        onChangeText={setTitle}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Due (YYYY-MM-DD HH:MM)"
+        value={due}
+        onChangeText={setDue}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Urgency 1-5"
+        value={urgency}
+        onChangeText={setUrgency}
+      />
+      <Button title="Add Task" color={colors.primary} onPress={submit} />
       <FlatList
         data={tasks}
         keyExtractor={item => item.id}
-        renderItem={({ item }) => (
-          <TouchableOpacity onPress={() => dispatch(toggleTask(item.id))}>
-            <Text style={item.completed ? styles.done : styles.item}>{item.title}</Text>
-          </TouchableOpacity>
-        )}
+        renderItem={({ item }) => <TaskItem item={item} />}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
       />
     </View>
@@ -40,6 +137,30 @@ const styles = StyleSheet.create({
     fontSize: 18,
     paddingVertical: 8,
     color: colors.text,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 8,
+    backgroundColor: '#fff',
+    borderRadius: 4,
+  },
+  meta: {
+    color: '#666',
+    fontSize: 12,
+  },
+  timer: {
+    fontSize: 12,
+    color: colors.primary,
+  },
+  taskRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  taskInfo: {
+    flex: 1,
   },
   done: {
     fontSize: 18,

--- a/src/store/tasksSlice.js
+++ b/src/store/tasksSlice.js
@@ -16,8 +16,23 @@ const tasksSlice = createSlice({
         task.completed = !task.completed;
       }
     },
+    startTask: (state, action) => {
+      const task = state.find(t => t.id === action.payload);
+      if (task && !task.startedAt) {
+        task.startedAt = Date.now();
+      }
+    },
+    stopTask: (state, action) => {
+      const task = state.find(t => t.id === action.payload);
+      if (task && task.startedAt) {
+        const duration = Date.now() - task.startedAt;
+        task.timeSpent = (task.timeSpent || 0) + duration;
+        task.startedAt = null;
+      }
+    },
   },
 });
 
-export const { addTask, removeTask, toggleTask } = tasksSlice.actions;
+export const { addTask, removeTask, toggleTask, startTask, stopTask } =
+  tasksSlice.actions;
 export default tasksSlice.reducer;


### PR DESCRIPTION
## Summary
- allow tasks to be created with due time and urgency
- log time spent on tasks with start/stop actions
- display a 25‑minute Pomodoro countdown for running tasks
- show next task due time on the home screen

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6841da64d5588320bcb7bed5396359eb